### PR TITLE
Preview build deployment failure

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,5 @@
+# Fix: assets:precompile requires secret_key_base in production.
+# Railway injects the real values at runtime; these placeholders are only for the build phase.
+[variables]
+SECRET_KEY_BASE = "build-placeholder"
+COOKIE_SECRET_TOKEN = "build-placeholder"


### PR DESCRIPTION
Fix Railway preview deployment failures by conditionally running migrations and explicitly ordering build steps.

Commit a73bb98 introduced a bug where `rake assets:precompile` could run before `npm run build` finished, causing `Setlist.js` to be missing. This PR also addresses preview deployments failing when `DATABASE_URL` is not set by skipping `db:migrate` in such cases.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-0ca21b94-73a5-4748-9ea4-6ecd63cfadea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0ca21b94-73a5-4748-9ea4-6ecd63cfadea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

