### PR TITLE
Railway deploy migration issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@
               /_/   /_/
 ```
 
-## This is the code that makes up the official [Blitzen Trapper band site](http://www.blitzentrapper.net).
+## This is the code that makes up the official [Blitzen Trapper band site](http://www.[REDACTED].net).
 
 If you see a bug, please
-feel free to [submit a fix](https://github.com/TRMW/blitzentrapper/pulls), or [file an issue](https://github.com/TRMW/blitzentrapper/issues).
+feel free to [submit a fix](https://github.com/TRMW/[REDACTED]/pulls), or [file an issue](https://github.com/TRMW/[REDACTED]/issues).
 
 **Thanks for trapping!**
 
@@ -71,7 +71,9 @@ Production and local development use [Neon](https://neon.tech) Postgres. The app
 
 ### Production
 
-Set `DATABASE_URL` on Railway to your Neon production connection string (pooled is fine; the app sets `search_path` after connect). Get it from the [Neon Console](https://console.neon.tech) → your project → production branch → Connect.
+Set `DATABASE_URL` on Railway to your Neon production connection string (pooled is fine; the app sets `search_path` after connect and disables prepared statements for pooler compatibility). Get it from the [Neon Console](https://console.neon.tech) → your project → production branch → Connect.
+
+If migrations fail with `PG::InFailedSqlTransaction`, try using Neon's **direct** (non-pooled) connection string instead of the pooled one for `DATABASE_URL`.
 
 ### Local development — Neon branch clone of production
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -20,6 +20,10 @@ production:
   database: blitzen_db_production
   pool: 5
   timeout: 5000
+  # Disable prepared statements when using Neon's pooled connection (PgBouncer).
+  # Transaction pooling doesn't preserve session state; prepared statements cause
+  # PG::InFailedSqlTransaction and similar errors during migrations.
+  prepared_statements: <%= ENV['DATABASE_URL'].present? ? false : true %>
   <% if ENV['DATABASE_URL'].present? %>
   url: <%= ENV['DATABASE_URL'] %>
   <% end %>

--- a/db/migrate/20250101000001_add_service_name_to_active_storage_blobs.rb
+++ b/db/migrate/20250101000001_add_service_name_to_active_storage_blobs.rb
@@ -3,9 +3,11 @@ class AddServiceNameToActiveStorageBlobs < ActiveRecord::Migration[6.1]
     unless column_exists?(:active_storage_blobs, :service_name)
       add_column :active_storage_blobs, :service_name, :string
 
-      if configured_service = ActiveStorage::Blob.service.name
-        ActiveStorage::Blob.unscoped.update_all(service_name: configured_service)
-      end
+      # Use config directly to avoid instantiating the storage service (e.g. S3),
+      # which can fail during deploy when credentials or network are unavailable.
+      configured_service = Rails.application.config.active_storage.service
+      service_name = (configured_service || :local).to_s
+      ActiveStorage::Blob.unscoped.update_all(service_name: service_name)
 
       change_column :active_storage_blobs, :service_name, :string, null: false
     end


### PR DESCRIPTION
Fix `AddServiceNameToActiveStorageBlobs` migration to prevent failure during Railway deploys.

The original migration called `ActiveStorage::Blob.service.name`, which attempts to instantiate the configured storage service (e.g., S3). This can fail during the Railway release phase if AWS credentials or network connectivity are not yet fully established. The updated migration now uses `Rails.application.config.active_storage.service` to retrieve the service name, which only reads from the application configuration and avoids any external service instantiation.

---
<p><a href="https://cursor.com/agents/bc-8e6c6bcf-7e24-45df-a6f1-6ce0cde33299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e6c6bcf-7e24-45df-a6f1-6ce0cde33299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

