### PR TITLE
Development environment setup for Cloud Agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,3 +44,5 @@ bin/rails test
 - reCAPTCHA is enabled on user signup and contact pages. The injected `RECAPTCHA_SITE_KEY`/`RECAPTCHA_SECRET_KEY` are for the production domain, not localhost. To create users locally, use `bin/rails console` (e.g. `User.new(login: "name", email: "e@x.com", password: "pw").save!`).
 - `yarn install --check-files` may be needed after switching branches if JS deps change; Webpacker's integrity check will refuse to start the server otherwise.
 - Standard dev commands are in README.md and `Procfile`. `bin/rails server` starts Puma on port 3000.
+- PostgreSQL may need to be started manually: `sudo pg_ctlcluster 16 main start`. Check with `pg_isready`.
+- Authlogic's `User` model does not have `password_confirmation`; use only `password` when creating users programmatically.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates `AGENTS.md` with additional gotchas discovered during environment setup for Cursor Cloud agents.

### Changes

* Added note about PostgreSQL needing manual start (`sudo pg_ctlcluster 16 main start`)
* Added note about Authlogic's `User` model not having `password_confirmation` (use only `password`)

### Environment Setup Verified

| Check | Status |
|---|---|
| Ruby 3.1.0 via rbenv | ✅ |
| Node.js v22 + Yarn 1.22 | ✅ |
| PostgreSQL 16 (trust auth) | ✅ |
| `bundle install` | ✅ |
| `yarn install` | ✅ |
| DB create + migrate (dev & test) | ✅ |
| `bin/rails test` (1 test, 0 failures) | ✅ |
| Dev server on port 3000 | ✅ |
| User creation + login | ✅ |

### Demo

[demo_blitzen_trapper_login.mp4](https://cursor.com/agents/bc-20102c7b-ffe1-49f8-b0ec-49f5c3918e1b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_blitzen_trapper_login.mp4)

Homepage and successful login as `testuser`:

[Homepage loaded](https://cursor.com/agents/bc-20102c7b-ffe1-49f8-b0ec-49f5c3918e1b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_loaded.webp)
[Login successful](https://cursor.com/agents/bc-20102c7b-ffe1-49f8-b0ec-49f5c3918e1b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flogin_successful.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20102c7b-ffe1-49f8-b0ec-49f5c3918e1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20102c7b-ffe1-49f8-b0ec-49f5c3918e1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

