### PR TITLE
Complete Neon-to-Railway migration for cloud token environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ railway link   # select your project + environment
 NEON_DATABASE_URL="postgres://user:pass@ep-xyz.us-east-2.aws.neon.tech/neondb" \
   bin/migrate-neon-to-railway
 
+# Optional: bypass Railway CLI lookup by passing destination DB URL directly
+NEON_DATABASE_URL="postgres://user:pass@ep-xyz.us-east-2.aws.neon.tech/neondb" \
+RAILWAY_DATABASE_URL="postgres://postgres:pass@containers-us-west-xyz.railway.app:6543/railway" \
+  bin/migrate-neon-to-railway
+
 # If Neon runs PG 17 and your local pg_dump is older, point to PG 17 tools:
 PG_DUMP=/usr/lib/postgresql/17/bin/pg_dump \
 PG_RESTORE=/usr/lib/postgresql/17/bin/pg_restore \
@@ -94,7 +99,9 @@ NEON_DATABASE_URL="postgres://..." \
   bin/migrate-neon-to-railway
 ```
 
-The script fetches the Railway `DATABASE_URL` automatically via `railway variables`.
+The script fetches the Railway `DATABASE_URL` automatically via `railway variables`/`railway variable list`.
+If Railway CLI auth is unavailable in your environment (for example, scoped/project token limitations),
+set `RAILWAY_DATABASE_URL` directly.
 
 ### Local development
 

--- a/bin/migrate-neon-to-railway
+++ b/bin/migrate-neon-to-railway
@@ -4,13 +4,17 @@ set -euo pipefail
 # Migrate Neon Postgres data to Railway Postgres.
 #
 # Prerequisites:
-#   1. Railway CLI installed and authenticated:  railway login
-#   2. Railway project linked:                   railway link
-#   3. Postgres plugin added to the project in the Railway dashboard
-#   4. NEON_DATABASE_URL set to the Neon connection string
+#   1. Postgres plugin added to the Railway project
+#   2. NEON_DATABASE_URL set to the Neon connection string
+#   3. Railway destination available via one of:
+#      - RAILWAY_DATABASE_URL (direct connection string), or
+#      - Railway CLI with project linked (`railway link`) so DATABASE_URL can be read
 #
 # Usage:
 #   NEON_DATABASE_URL="postgres://..." bin/migrate-neon-to-railway
+#   NEON_DATABASE_URL="postgres://..." \
+#   RAILWAY_DATABASE_URL="postgres://..." \
+#   bin/migrate-neon-to-railway
 #
 # If your Neon server runs PG 17+ and your local pg_dump is older,
 # override the tool paths:
@@ -30,21 +34,50 @@ if [[ -z "${NEON_DATABASE_URL:-}" ]]; then
   exit 1
 fi
 
-echo "==> Checking Railway CLI authentication..."
-if ! railway whoami >/dev/null 2>&1 || railway whoami 2>&1 | grep -qi unauthorized; then
-  echo "Error: Not authenticated with Railway. Run: railway login" >&2
-  exit 1
+read_database_url_from_json() {
+  python3 -c "import sys,json; print((json.load(sys.stdin) or {}).get('DATABASE_URL',''))" 2>/dev/null || true
+}
+
+echo "==> Resolving Railway DATABASE_URL..."
+if [[ -n "${RAILWAY_DATABASE_URL:-}" ]]; then
+  echo "  Using RAILWAY_DATABASE_URL from environment."
+else
+  if ! command -v railway >/dev/null 2>&1; then
+    echo "Error: railway CLI not found and RAILWAY_DATABASE_URL is not set." >&2
+    echo "Install Railway CLI or set RAILWAY_DATABASE_URL directly." >&2
+    exit 1
+  fi
+
+  # Prefer explicit IDs when present; this supports non-linked environments in CI/agents.
+  RAILWAY_SERVICE_OPT=()
+  RAILWAY_ENV_OPT=()
+  if [[ -n "${RAILWAY_SERVICE_ID:-}" ]]; then
+    RAILWAY_SERVICE_OPT=(-s "${RAILWAY_SERVICE_ID}")
+  elif [[ -n "${RAILWAY_SERVICE:-}" ]]; then
+    RAILWAY_SERVICE_OPT=(-s "${RAILWAY_SERVICE}")
+  fi
+  if [[ -n "${RAILWAY_ENVIRONMENT_ID:-}" ]]; then
+    RAILWAY_ENV_OPT=(-e "${RAILWAY_ENVIRONMENT_ID}")
+  elif [[ -n "${RAILWAY_ENVIRONMENT:-}" ]]; then
+    RAILWAY_ENV_OPT=(-e "${RAILWAY_ENVIRONMENT}")
+  fi
+
+  # Railway CLI has changed command spellings across versions; try both.
+  RAILWAY_DATABASE_URL="$(railway variable list --json "${RAILWAY_SERVICE_OPT[@]}" "${RAILWAY_ENV_OPT[@]}" 2>/dev/null | read_database_url_from_json || true)"
+  if [[ -z "${RAILWAY_DATABASE_URL}" ]]; then
+    RAILWAY_DATABASE_URL="$(railway variables --json "${RAILWAY_SERVICE_OPT[@]}" "${RAILWAY_ENV_OPT[@]}" 2>/dev/null | read_database_url_from_json || true)"
+  fi
+  if [[ -z "${RAILWAY_DATABASE_URL}" ]]; then
+    RAILWAY_DATABASE_URL="$(railway variable list "${RAILWAY_SERVICE_OPT[@]}" "${RAILWAY_ENV_OPT[@]}" 2>/dev/null | grep '^DATABASE_URL=' | cut -d= -f2- || true)"
+  fi
+  if [[ -z "${RAILWAY_DATABASE_URL}" ]]; then
+    RAILWAY_DATABASE_URL="$(railway variables "${RAILWAY_SERVICE_OPT[@]}" "${RAILWAY_ENV_OPT[@]}" 2>/dev/null | grep '^DATABASE_URL=' | cut -d= -f2- || true)"
+  fi
 fi
 
-echo "==> Fetching Railway DATABASE_URL..."
-RAILWAY_DATABASE_URL="$(railway variables --json 2>/dev/null \
-  | python3 -c "import sys,json; print(json.load(sys.stdin).get('DATABASE_URL',''))" 2>/dev/null || true)"
 if [[ -z "${RAILWAY_DATABASE_URL}" ]]; then
-  RAILWAY_DATABASE_URL="$(railway variables 2>/dev/null | grep '^DATABASE_URL=' | cut -d= -f2- || true)"
-fi
-if [[ -z "${RAILWAY_DATABASE_URL}" ]]; then
-  echo "Error: Could not find DATABASE_URL in Railway variables." >&2
-  echo "Make sure a Postgres plugin is attached to your Railway service." >&2
+  echo "Error: Could not resolve Railway DATABASE_URL." >&2
+  echo "Set RAILWAY_DATABASE_URL directly, or run railway link and ensure a Postgres plugin is attached." >&2
   exit 1
 fi
 echo "  Railway DB URL found (host: $(echo "$RAILWAY_DATABASE_URL" | sed 's|.*@\([^/]*\)/.*|\1|'))"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Complete the Neon→Railway migration flow on this branch by incorporating the missing cloud-token-safe migration update from prior agent work.
- `bin/migrate-neon-to-railway` now supports direct `RAILWAY_DATABASE_URL` input and no longer hard-depends on `railway whoami`.
- Script resolves Railway DB URL via env var first, then CLI (`railway variable list` / `railway variables`, JSON and key/value fallback), with explicit `RAILWAY_SERVICE(_ID)` and `RAILWAY_ENVIRONMENT(_ID)` support.
- README migration docs now include direct `RAILWAY_DATABASE_URL` usage for scoped/project token environments.

## Testing
- ✅ `bash -n bin/migrate-neon-to-railway`
- ✅ `PATH="/tmp/migration_test_bin:$PATH" NEON_DATABASE_URL="postgres://neon.example/db" RAILWAY_DATABASE_URL="postgres://railway.example/db" bin/migrate-neon-to-railway`
- ✅ `PATH="/tmp/migration_test_bin:$PATH" NEON_DATABASE_URL="postgres://neon.example/db" bin/migrate-neon-to-railway` (expected clear failure when destination URL unavailable)

## Notes
- Attempted to execute the live Railway migration using `RAILWAY_TOKEN_NEW`, but Railway API returned Unauthorized/Invalid for all CLI auth paths in this environment.
- This change ensures migration can still be executed by supplying `RAILWAY_DATABASE_URL` directly when CLI token scope is limited.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e08da9e-ca36-42b6-899a-259351d0885e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e08da9e-ca36-42b6-899a-259351d0885e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

