### PR TITLE
Fix setlistings_with_blanks serialization for unsaved records

### DIFF
--- a/app/models/show.rb
+++ b/app/models/show.rb
@@ -44,7 +44,7 @@ class Show < ActiveRecord::Base
 
     attrs = attributes.dup
     attrs['setlistings'] = setlistings_with_blanks.map do |s|
-      s.as_json(setlistings_config)
+      s.as_json(setlistings_config || {})
     end
 
     attrs.to_json


### PR DESCRIPTION
Pass empty hash to as_json when setlistings_config is nil to properly serialize blank Setlisting records that don't have a song association yet.